### PR TITLE
Attempt: make store instance of the test case.

### DIFF
--- a/BadAccessPlaygroundTests/BadAccessPlaygroundTests.swift
+++ b/BadAccessPlaygroundTests/BadAccessPlaygroundTests.swift
@@ -22,12 +22,14 @@ class Store {
 }
 
 final class BadAccessPlaygroundTests: XCTestCase {
+    var store = Store()
+    
     func testBadAccess() {
         let expectation = expectation(description: "expectation")
         var task: AnyCancellable?
         
         task = Future<Item, Never> { promise in
-            Store.shared.fetchItem() { result in
+            self.store.fetchItem() { result in
                 promise(.success(result))
             }
         }


### PR DESCRIPTION
Regarding this thread: https://social.lol/@ryanashcraft@mastodon.social/111177380156479405

Using Store as singleton crashes on my machine as well. This solution however, crashed zero times since I built it (and it's been made before I started thread on the mastodon mentioning the store).